### PR TITLE
Fix strict mode error

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function (obj, namespace) {
 				'[object Array]')) {
 		throw new Error('nsKeyMirror map must be an object!');
 	}
-	for (key in obj) {
+	for (var key in obj) {
 		if (obj.hasOwnProperty(key)) {
 			if (namespace) {
 				o[key] = key + '@' + namespace;


### PR DESCRIPTION
`ReferenceError: Strict mode forbids implicit creation of global property 'key'`